### PR TITLE
Fix/oauth csrf

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -3,12 +3,14 @@
 import { LoginError } from "@/application/usecases/auth/errors/LoginError";
 import { Button, Input } from "@/components/common";
 import { useUserStore } from "@/utils/stores/userStore";
-import { useRouter } from "next/navigation";
-import { useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useRef, useState } from "react";
 
 const SignUp = () => {
   // React Router 호출
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const isKakao = searchParams.get("provider") === "kakao";
   // Zustand에서 fetchUser 가져오기
   const { fetchUser } = useUserStore();
 
@@ -372,7 +374,39 @@ const SignUp = () => {
     router.push("/play/character");
   };
   /* 가입 끝 */
-  
+
+
+  /* 카카오 가입 시작 */
+  const handleKakaoSignUp = async () => {
+    const nickname = nicknameRef.current?.value;
+
+    setNicknameEmpty(!nickname);
+    if (!nickname) return;
+
+    try {
+      const response = await fetch('/api/auth/kakao/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nickname }),
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        alert(data.error || "가입 중 오류가 발생했습니다.");
+        return;
+      }
+    } catch (error) {
+      console.error("카카오 가입 오류:", error);
+      return;
+    }
+
+    alert("가입이 완료되었습니다!");
+    await fetchUser();
+    router.push("/play/character");
+  };
+  /* 카카오 가입 끝 */
+
 
   return (
     <div className={
@@ -394,8 +428,9 @@ const SignUp = () => {
         `
         .replace(/\s+/g, ' ').trim()
         }>
-            <span>회원가입</span>
+            <span>{isKakao ? "닉네임 설정" : "회원가입"}</span>
         </h1>
+        {!isKakao && (
         <div className="row relative w-full flex flex-col">
             <div className={`
                 w-full
@@ -430,7 +465,8 @@ const SignUp = () => {
             </span>
             )}
         </div>
-        <div className="row relative w-full flex flex-col mt-[26px]">
+        )}
+        <div className={`row relative w-full flex flex-col ${isKakao ? "" : "mt-[26px]"}`}>
             <Input placeholder="닉네임" className="is-rounded-form w-full shadow-none"
               ref={nicknameRef} onChange={handleNicknameChange} />
             {nicknameEmpty && (
@@ -446,6 +482,7 @@ const SignUp = () => {
             </span>
             )}
         </div>
+        {!isKakao && (
         <div className="row relative w-full flex flex-col mt-[26px]">
             <div className={`
                 w-full
@@ -501,6 +538,9 @@ const SignUp = () => {
             </span>
             )}
         </div>
+        )}
+        {!isKakao && (
+        <>
         <div className="row relative w-full flex flex-col mt-[26px]">
             <Input placeholder="비밀번호" className="is-rounded-form w-full shadow-none" type="password"
               ref={passwordRef} value={password} onChange={handlePasswordChange} />
@@ -613,12 +653,20 @@ const SignUp = () => {
             </span>
             )}
         </div>
+        </>
+        )}
         <div className="row w-full mt-[60px]">
             <Button style={{ width: "100%", marginLeft: 0, marginRight: 0 }} state="success" size="L"
-              onClick={handleSignUp}>가입하기</Button>
+              onClick={isKakao ? handleKakaoSignUp : handleSignUp}>가입하기</Button>
         </div>
     </div>
   );
 };
 
-export default SignUp;
+const SignUpPage = () => (
+  <Suspense>
+    <SignUp />
+  </Suspense>
+);
+
+export default SignUpPage;

--- a/app/api/auth/check-exist-email/route.ts
+++ b/app/api/auth/check-exist-email/route.ts
@@ -2,11 +2,28 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { PriUserRepository } from '@/infrastructure/repositories/PriUserRepository';
 import { CheckExistEmailUsecase } from '@/application/usecases/auth/CheckExistEmailUsecase';
+import { checkRateLimit, getClientIp } from '@/infrastructure/rate-limiter';
 
 const userRepository = new PriUserRepository(prisma);
 const checkExistEmailUsecase = new CheckExistEmailUsecase(userRepository);
 
+const ENUM_RATE_LIMIT = { maxRequests: 10, windowSeconds: 60 };
+
 export async function POST(req: NextRequest) {
+    const clientIp = getClientIp(req.headers);
+    const rateLimit = await checkRateLimit(
+        `check-email:${clientIp}`,
+        ENUM_RATE_LIMIT.maxRequests,
+        ENUM_RATE_LIMIT.windowSeconds
+    );
+
+    if (!rateLimit.allowed) {
+        return NextResponse.json(
+            { error: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." },
+            { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } }
+        );
+    }
+
     const { email } = await req.json();
 
     if (!email || typeof email !== 'string') {
@@ -17,6 +34,6 @@ export async function POST(req: NextRequest) {
         const isExist = await checkExistEmailUsecase.execute({ email });
         return NextResponse.json(isExist, { status: 200 });
     } catch (error) {
-        return NextResponse.json({ error: (error as Error).message }, { status: 404 });
+        return NextResponse.json({ error: "요청을 처리할 수 없습니다." }, { status: 500 });
     }
 }

--- a/app/api/auth/check-exist-login-id/route.ts
+++ b/app/api/auth/check-exist-login-id/route.ts
@@ -2,11 +2,28 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { PriUserRepository } from '@/infrastructure/repositories/PriUserRepository';
 import { CheckExistLoginIdUsecase } from '@/application/usecases/auth/CheckExistLoginIdUsecase';
+import { checkRateLimit, getClientIp } from '@/infrastructure/rate-limiter';
 
 const userRepository = new PriUserRepository(prisma);
 const checkExistLoginIdUsecase = new CheckExistLoginIdUsecase(userRepository);
 
+const ENUM_RATE_LIMIT = { maxRequests: 10, windowSeconds: 60 };
+
 export async function POST(req: NextRequest) {
+    const clientIp = getClientIp(req.headers);
+    const rateLimit = await checkRateLimit(
+        `check-loginid:${clientIp}`,
+        ENUM_RATE_LIMIT.maxRequests,
+        ENUM_RATE_LIMIT.windowSeconds
+    );
+
+    if (!rateLimit.allowed) {
+        return NextResponse.json(
+            { error: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." },
+            { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } }
+        );
+    }
+
     const { loginId } = await req.json();
 
     if (!loginId || typeof loginId !== 'string') {
@@ -17,6 +34,6 @@ export async function POST(req: NextRequest) {
         const isExist = await checkExistLoginIdUsecase.execute({ loginId });
         return NextResponse.json(isExist, { status: 200 });
     } catch (error) {
-        return NextResponse.json({ error: (error as Error).message }, { status: 404 });
+        return NextResponse.json({ error: "요청을 처리할 수 없습니다." }, { status: 500 });
     }
 }

--- a/app/api/auth/check-verify-code/route.ts
+++ b/app/api/auth/check-verify-code/route.ts
@@ -2,10 +2,28 @@ import { CheckVerifyCodeUsecase } from "@/application/usecases/auth/CheckVerifyC
 import { DeleteVerifyCodeUsecase } from "@/application/usecases/auth/DeleteVerifyCodeUsecase";
 import { RdVerificationRepository } from "@/infrastructure/repositories/RdVerificationRepository";
 import { NextRequest, NextResponse } from "next/server";
+import { checkRateLimit, getClientIp } from "@/infrastructure/rate-limiter";
+
+const VERIFY_RATE_LIMIT = { maxRequests: 5, windowSeconds: 300 };
 
 export async function POST(req: NextRequest) {
-    
+
     try {
+        // Rate Limiting: 인증 코드 브루트포스 방지
+        const clientIp = getClientIp(req.headers);
+        const rateLimit = await checkRateLimit(
+            `verify-code:${clientIp}`,
+            VERIFY_RATE_LIMIT.maxRequests,
+            VERIFY_RATE_LIMIT.windowSeconds
+        );
+
+        if (!rateLimit.allowed) {
+            return NextResponse.json(
+                { error: "인증 시도가 너무 많습니다. 5분 후 다시 시도해주세요." },
+                { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } }
+            );
+        }
+
         // Client Request json parsed
         const { email, verificationCode } = await req.json();
 

--- a/app/api/auth/find-login-id/route.ts
+++ b/app/api/auth/find-login-id/route.ts
@@ -2,11 +2,28 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { PriUserRepository } from '@/infrastructure/repositories/PriUserRepository';
 import { FindLoginIdByEmailUsecase } from '@/application/usecases/auth/FindLoginIdByEmailUsecase';
+import { checkRateLimit, getClientIp } from '@/infrastructure/rate-limiter';
 
 const userRepository = new PriUserRepository(prisma);
 const findLoginIdByEmailUsecase = new FindLoginIdByEmailUsecase(userRepository);
 
+const FIND_ID_RATE_LIMIT = { maxRequests: 5, windowSeconds: 60 };
+
 export async function POST(req: NextRequest) {
+    const clientIp = getClientIp(req.headers);
+    const rateLimit = await checkRateLimit(
+        `find-loginid:${clientIp}`,
+        FIND_ID_RATE_LIMIT.maxRequests,
+        FIND_ID_RATE_LIMIT.windowSeconds
+    );
+
+    if (!rateLimit.allowed) {
+        return NextResponse.json(
+            { error: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." },
+            { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } }
+        );
+    }
+
     const { email } = await req.json();
 
     if (!email || typeof email !== 'string') {
@@ -17,6 +34,6 @@ export async function POST(req: NextRequest) {
         const loginId = await findLoginIdByEmailUsecase.execute(email);
         return NextResponse.json({ loginId }, { status: 200 });
     } catch (error) {
-        return NextResponse.json({ error: (error as Error).message }, { status: 404 });
+        return NextResponse.json({ error: "요청을 처리할 수 없습니다." }, { status: 500 });
     }
 }

--- a/app/api/auth/kakao/callback/route.ts
+++ b/app/api/auth/kakao/callback/route.ts
@@ -50,39 +50,38 @@ export async function GET(req: NextRequest) {
     const kakaoNickname = kakaoUser.properties?.nickname || "헌터";
     const kakaoEmail = kakaoUser.kakao_account?.email || `kakao_${kakaoId}@todohunter.local`;
 
-    // 3. DB에서 기존 카카오 사용자 조회 또는 신규 생성
-    let user = await prisma.user.findUnique({
+    // 사용 완료된 CSRF state 쿠키 삭제
+    const deleteCsrfCookie = (res: NextResponse) => {
+      res.cookies.delete("kakao_oauth_state");
+    };
+
+    // 3. DB에서 기존 카카오 사용자 조회
+    const user = await prisma.user.findUnique({
       where: { providerId: kakaoId },
     });
 
     if (!user) {
-      // 신규 사용자 생성 (User + Character + Status)
-      user = await prisma.user.create({
-        data: {
-          loginId: `kakao_${kakaoId}`,
-          email: kakaoEmail,
-          password: null,
-          nickname: kakaoNickname,
-          provider: "kakao",
-          providerId: kakaoId,
-          characters: {
-            create: {
-              endingState: 0,
-              status: {
-                create: {
-                  str: 0,
-                  int: 0,
-                  emo: 0,
-                  fin: 0,
-                  liv: 0,
-                },
-              },
-            },
-          },
-        },
+      // 신규 사용자: 닉네임 입력을 위해 signup 페이지로 리다이렉트
+      const response = NextResponse.redirect(new URL("/signup?provider=kakao", req.url));
+
+      // 카카오 데이터를 HttpOnly 쿠키에 임시 저장 (5분 만료)
+      response.cookies.set("kakao_pending", JSON.stringify({
+        kakaoId,
+        kakaoEmail,
+        kakaoNickname,
+      }), {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+        sameSite: "lax",
+        maxAge: 300,
       });
+
+      deleteCsrfCookie(response);
+      return response;
     }
 
+    // 기존 사용자: 바로 로그인 처리
     // 4. JWT 토큰 발급 (기존 시스템 활용)
     const generateAccessToken = new GenerateAccessTokenUsecase();
     const generateRefreshToken = new GenerateRefreshTokenUsecase(new RdAuthenticationRepository());
@@ -122,8 +121,7 @@ export async function GET(req: NextRequest) {
       maxAge: 31536000,
     });
 
-    // 사용 완료된 CSRF state 쿠키 삭제
-    response.cookies.delete("kakao_oauth_state");
+    deleteCsrfCookie(response);
 
     return response;
   } catch (error) {

--- a/app/api/auth/kakao/callback/route.ts
+++ b/app/api/auth/kakao/callback/route.ts
@@ -8,9 +8,17 @@ export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
     const code = searchParams.get("code");
+    const state = searchParams.get("state");
 
     if (!code) {
       return NextResponse.redirect(new URL("/signin?error=no_code", req.url));
+    }
+
+    // CSRF 검증: 쿠키에 저장된 state와 콜백의 state 비교
+    const savedState = req.cookies.get("kakao_oauth_state")?.value;
+
+    if (!state || !savedState || state !== savedState) {
+      return NextResponse.redirect(new URL("/signin?error=invalid_state", req.url));
     }
 
     // 1. 인가 코드로 카카오 액세스 토큰 발급
@@ -96,6 +104,7 @@ export async function GET(req: NextRequest) {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       path: "/",
+      sameSite: "strict",
       maxAge: parseInt((process.env.ACCESS_TOKEN_EXPIRES || "3600").replace("s", ""), 10),
     });
 
@@ -103,6 +112,7 @@ export async function GET(req: NextRequest) {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       path: "/",
+      sameSite: "strict",
       maxAge: parseInt((process.env.REFRESH_TOKEN_EXPIRES || "3600").replace("s", ""), 10),
     });
 
@@ -112,9 +122,12 @@ export async function GET(req: NextRequest) {
       maxAge: 31536000,
     });
 
+    // 사용 완료된 CSRF state 쿠키 삭제
+    response.cookies.delete("kakao_oauth_state");
+
     return response;
   } catch (error) {
-    console.error("카카오 로그인 오류:", error);
+    console.error("카카오 로그인 오류:", error instanceof Error ? error.message : "unknown error");
     return NextResponse.redirect(new URL("/signin?error=kakao_failed", req.url));
   }
 }

--- a/app/api/auth/kakao/route.ts
+++ b/app/api/auth/kakao/route.ts
@@ -1,8 +1,44 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { checkRateLimit, getClientIp } from "@/infrastructure/rate-limiter";
+
+// 카카오 로그인: 같은 IP에서 60초 내 최대 5회
+const KAKAO_RATE_LIMIT = { maxRequests: 5, windowSeconds: 60 };
 
 // 카카오 로그인 페이지로 리다이렉트
-export async function GET() {
-  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=${encodeURIComponent(process.env.KAKAO_REDIRECT_URI!)}&response_type=code`;
+export async function GET(req: NextRequest) {
+  // Rate Limiting 검사
+  const clientIp = getClientIp(req.headers);
+  const rateLimit = await checkRateLimit(
+    `kakao:${clientIp}`,
+    KAKAO_RATE_LIMIT.maxRequests,
+    KAKAO_RATE_LIMIT.windowSeconds
+  );
 
-  return NextResponse.redirect(kakaoAuthUrl);
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
+      }
+    );
+  }
+  // CSRF 방지를 위한 state 토큰 생성
+  const state = crypto.randomBytes(32).toString("hex");
+
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=${encodeURIComponent(process.env.KAKAO_REDIRECT_URI!)}&response_type=code&state=${state}`;
+
+  const response = NextResponse.redirect(kakaoAuthUrl);
+
+  // state 값을 HttpOnly 쿠키에 저장 (콜백에서 검증용)
+  response.cookies.set("kakao_oauth_state", state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 600, // 10분 후 만료
+    sameSite: "lax",
+  });
+
+  return response;
 }

--- a/app/api/auth/kakao/signup/route.ts
+++ b/app/api/auth/kakao/signup/route.ts
@@ -1,0 +1,140 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { GenerateAccessTokenUsecase } from "@/application/usecases/auth/GenerateAccessTokenUsecase";
+import { GenerateRefreshTokenUsecase } from "@/application/usecases/auth/GenerateRefreshTokenUsecase";
+import { RdAuthenticationRepository } from "@/infrastructure/repositories/RdAuthenticationRepository";
+import { checkRateLimit, getClientIp } from "@/infrastructure/rate-limiter";
+
+const KAKAO_SIGNUP_RATE_LIMIT = { maxRequests: 3, windowSeconds: 60 };
+
+export async function POST(req: NextRequest) {
+  try {
+    // Rate Limiting
+    const clientIp = getClientIp(req.headers);
+    const rateLimit = await checkRateLimit(
+      `kakao-signup:${clientIp}`,
+      KAKAO_SIGNUP_RATE_LIMIT.maxRequests,
+      KAKAO_SIGNUP_RATE_LIMIT.windowSeconds
+    );
+
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." },
+        { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } }
+      );
+    }
+
+    // kakao_pending 쿠키에서 카카오 데이터 읽기
+    const pendingCookie = req.cookies.get("kakao_pending")?.value;
+    if (!pendingCookie) {
+      return NextResponse.json(
+        { error: "카카오 인증 정보가 만료되었습니다. 다시 로그인해주세요." },
+        { status: 400 }
+      );
+    }
+
+    const { kakaoId, kakaoEmail } = JSON.parse(pendingCookie);
+    if (!kakaoId || !kakaoEmail) {
+      return NextResponse.json(
+        { error: "카카오 인증 정보가 올바르지 않습니다." },
+        { status: 400 }
+      );
+    }
+
+    // 요청 body에서 닉네임 받기
+    const { nickname } = await req.json();
+    if (!nickname || typeof nickname !== "string" || nickname.trim().length === 0) {
+      return NextResponse.json(
+        { error: "닉네임을 입력해주세요." },
+        { status: 400 }
+      );
+    }
+
+    // 이미 가입된 사용자인지 재확인
+    const existingUser = await prisma.user.findUnique({
+      where: { providerId: kakaoId },
+    });
+
+    if (existingUser) {
+      return NextResponse.json(
+        { error: "이미 가입된 사용자입니다." },
+        { status: 409 }
+      );
+    }
+
+    // 유저 + 캐릭터 + 스테이터스 생성
+    const user = await prisma.user.create({
+      data: {
+        loginId: `kakao_${kakaoId}`,
+        email: kakaoEmail,
+        password: null,
+        nickname: nickname.trim(),
+        provider: "kakao",
+        providerId: kakaoId,
+        characters: {
+          create: {
+            endingState: 0,
+            status: {
+              create: {
+                str: 0,
+                int: 0,
+                emo: 0,
+                fin: 0,
+                liv: 0,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // JWT 토큰 발급
+    const generateAccessToken = new GenerateAccessTokenUsecase();
+    const generateRefreshToken = new GenerateRefreshTokenUsecase(new RdAuthenticationRepository());
+
+    const accessToken = await generateAccessToken.execute({
+      id: user.id,
+      loginId: user.loginId,
+    });
+
+    const refreshToken = await generateRefreshToken.execute({
+      id: user.id,
+      loginId: user.loginId,
+    });
+
+    // 응답 + 쿠키 설정
+    const response = NextResponse.json({ message: "가입 성공" }, { status: 201 });
+
+    response.cookies.set("accessToken", accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      sameSite: "strict",
+      maxAge: parseInt((process.env.ACCESS_TOKEN_EXPIRES || "3600").replace("s", ""), 10),
+    });
+
+    response.cookies.set("refreshToken", refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      sameSite: "strict",
+      maxAge: parseInt((process.env.REFRESH_TOKEN_EXPIRES || "3600").replace("s", ""), 10),
+    });
+
+    response.cookies.set("isBeginned", "true", {
+      path: "/",
+      maxAge: 31536000,
+    });
+
+    // 사용 완료된 kakao_pending 쿠키 삭제
+    response.cookies.delete("kakao_pending");
+
+    return response;
+  } catch (error) {
+    console.error("카카오 가입 오류:", error instanceof Error ? error.message : "unknown error");
+    return NextResponse.json(
+      { error: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/send-signup-email/route.ts
+++ b/app/api/auth/send-signup-email/route.ts
@@ -3,8 +3,24 @@ import { SendSignUpEmailUsecase } from "@/application/usecases/auth/SendSignUpEm
 
 import { RdVerificationRepository } from "@/infrastructure/repositories/RdVerificationRepository";
 import { NextRequest, NextResponse } from "next/server";
+import { checkRateLimit, getClientIp } from "@/infrastructure/rate-limiter";
+
+const EMAIL_RATE_LIMIT = { maxRequests: 3, windowSeconds: 120 };
 
 export async function POST(req: NextRequest) {
+  const clientIp = getClientIp(req.headers);
+  const rateLimit = await checkRateLimit(
+    `send-email:${clientIp}`,
+    EMAIL_RATE_LIMIT.maxRequests,
+    EMAIL_RATE_LIMIT.windowSeconds
+  );
+
+  if (!rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "이메일 발송 요청이 너무 많습니다. 잠시 후 다시 시도해주세요." },
+      { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } }
+    );
+  }
 
   try {
     const { email } = await req.json();

--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -13,9 +13,32 @@ import { GenerateRefreshTokenUsecase } from "@/application/usecases/auth/Generat
 import { VerifyRefreshTokenUsecase } from "@/application/usecases/auth/VerifyRefreshTokenUsecase";
 import { RenewRefreshTokenUsecase } from "@/application/usecases/auth/RenewRefreshTokenUsecase";
 import { FindUserIdByLoginIdUsecase } from "@/application/usecases/auth/FindUserIdByLoginIdUsecase";
+import { checkRateLimit, getClientIp } from "@/infrastructure/rate-limiter";
+
+// 로그인: 같은 IP에서 60초 내 최대 5회
+const LOGIN_RATE_LIMIT = { maxRequests: 5, windowSeconds: 60 };
 
 export async function POST(req: NextRequest) {
     try {
+        // Rate Limiting 검사
+        const clientIp = getClientIp(req.headers);
+        const rateLimit = await checkRateLimit(
+            `signin:${clientIp}`,
+            LOGIN_RATE_LIMIT.maxRequests,
+            LOGIN_RATE_LIMIT.windowSeconds
+        );
+
+        if (!rateLimit.allowed) {
+            return NextResponse.json(
+                { error: "로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요." },
+                {
+                    status: 429,
+                    headers: {
+                        "Retry-After": String(rateLimit.retryAfterSeconds),
+                    },
+                }
+            );
+        }
         const request: SignInRequestDTO = await req.json();
         const userRepository: IUserRepository = new PriUserRepository(prisma);
         const verifyPasswordUsecase = new VerifyPasswordUsecase();
@@ -61,34 +84,36 @@ export async function POST(req: NextRequest) {
         // 쿠키 설정 및 응답
         const response = NextResponse.json({ accessToken }, { status: 200 });
         response.cookies.set("accessToken", accessToken, {
-            httpOnly: true, // XSS 방지
-            secure: process.env.NODE_ENV === "production", // 프로덕션에서만 Secure 적용
-            path: "/", // 모든 경로에서 사용 가능
-            maxAge: parseInt(process.env.ACCESS_TOKEN_EXPIRES || "3600", 10), // 유효기간 (초 단위)
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            path: "/",
+            sameSite: "strict",
+            maxAge: parseInt(process.env.ACCESS_TOKEN_EXPIRES || "3600", 10),
         });
         response.cookies.set("refreshToken", refreshToken, {
             httpOnly: true,
             secure: process.env.NODE_ENV === "production",
             path: "/",
-            maxAge: parseInt(process.env.REFRESH_TOKEN_EXPIRES || "3600", 10), // 유효기간 (초 단위)
+            sameSite: "strict",
+            maxAge: parseInt(process.env.REFRESH_TOKEN_EXPIRES || "3600", 10),
         });
 
         return response;
     } catch (error) {
-        console.error("❌ 로그인 오류", error);
+        console.error("로그인 오류:", error instanceof Error ? error.message : "unknown error");
 
         if(error instanceof LoginError){
             const errorMapping: Record<LoginErrorType, {message: string; status: number}> = {
                 MISSING_CREDENTIALS: {
-                message: "이메일과 비밀번호를 모두 입력해주세요.",
+                message: "아이디와 비밀번호를 모두 입력해주세요.",
                 status: 400,
                 },
                 LOGIN_ID_NOT_FOUND: {
-                message: "가입되지 않은 아이디입니다. 회원가입 후 이용해주세요.",
+                message: "아이디 또는 비밀번호가 올바르지 않습니다.",
                 status: 401,
                 },
                 INVALID_PASSWORD: {
-                message: "비밀번호가 올바르지 않습니다. 다시 시도해주세요.",
+                message: "아이디 또는 비밀번호가 올바르지 않습니다.",
                 status: 401,
                 },
                 UNKNOWN_ERROR: {

--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -81,8 +81,8 @@ export async function POST(req: NextRequest) {
         // Access Token 생성
         const accessToken = await generateAccessTokenUsecase.execute({ id: id, loginId: loginId });
 
-        // 쿠키 설정 및 응답
-        const response = NextResponse.json({ accessToken }, { status: 200 });
+        // 쿠키 설정 및 응답 (토큰은 HttpOnly 쿠키로만 전달, body에 포함하지 않음)
+        const response = NextResponse.json({ message: "로그인 성공" }, { status: 200 });
         response.cookies.set("accessToken", accessToken, {
             httpOnly: true,
             secure: process.env.NODE_ENV === "production",

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -6,8 +6,25 @@ import { PriCharacterRepository, PriStatusRepository, PriUserRepository } from "
 import { RdAuthenticationRepository } from "@/infrastructure/repositories/RdAuthenticationRepository";
 import { prisma } from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
+import { checkRateLimit, getClientIp } from "@/infrastructure/rate-limiter";
+
+const SIGNUP_RATE_LIMIT = { maxRequests: 3, windowSeconds: 60 };
 
 export async function POST(req: NextRequest) {
+    const clientIp = getClientIp(req.headers);
+    const rateLimit = await checkRateLimit(
+        `signup:${clientIp}`,
+        SIGNUP_RATE_LIMIT.maxRequests,
+        SIGNUP_RATE_LIMIT.windowSeconds
+    );
+
+    if (!rateLimit.allowed) {
+        return NextResponse.json(
+            { error: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요." },
+            { status: 429, headers: { "Retry-After": String(rateLimit.retryAfterSeconds) } }
+        );
+    }
+
     const userData: SignUpRequestDTO = await req.json();
 
     // 필수 필드 체크
@@ -41,16 +58,18 @@ export async function POST(req: NextRequest) {
         // 쿠키 설정 및 응답
         const response = NextResponse.json({ message: "회원가입 성공" }, { status: 201 });
         response.cookies.set("accessToken", accessToken, {
-            httpOnly: true, // XSS 방지
-            secure: process.env.NODE_ENV === "production", // 프로덕션에서만 Secure 적용
-            path: "/", // 모든 경로에서 사용 가능
-            maxAge: parseInt(process.env.ACCESS_TOKEN_EXPIRES || "3600", 10), // 유효기간 (초 단위)
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            path: "/",
+            sameSite: "strict",
+            maxAge: parseInt(process.env.ACCESS_TOKEN_EXPIRES || "3600", 10),
         });
         response.cookies.set("refreshToken", refreshToken, {
             httpOnly: true,
             secure: process.env.NODE_ENV === "production",
             path: "/",
-            maxAge: parseInt(process.env.REFRESH_TOKEN_EXPIRES || "3600", 10), // 유효기간 (초 단위)
+            sameSite: "strict",
+            maxAge: parseInt(process.env.REFRESH_TOKEN_EXPIRES || "3600", 10),
         });
 
         return response;

--- a/app/api/quest/route.ts
+++ b/app/api/quest/route.ts
@@ -3,15 +3,21 @@ import { CreateQuestUseCase } from '@/application/usecases/quest/CreateQuestUsec
 import { PriQuestRepository, PriStatusRepository } from '@/infrastructure/repositories';
 import { prisma } from '@/lib/prisma';
 import { CreateQuestDTO } from '@/application/usecases/quest/dtos';
-import { getUserFromCookie, getUserFromRequest } from '@/utils/auth';
+import { getUserFromCookie } from '@/utils/auth';
 
 // POST 요청 (새 퀘스트 생성)
 export async function POST(req: NextRequest) {
   try {
     // 🔹 유저 정보 가져오기
-    const userId = await getUserFromRequest(req);
-    if (!userId || typeof userId !== "number") {
+    const { user } = await getUserFromCookie(req);
+    if (!user || !user.id) {
       return NextResponse.json({ success: false, error: "로그인이 필요합니다." }, { status: 401 });
+    }
+
+    // 🔹 유저의 캐릭터 조회
+    const character = await prisma.character.findFirst({ where: { userId: Number(user.id) } });
+    if (!character) {
+      return NextResponse.json({ success: false, error: "캐릭터를 찾을 수 없습니다." }, { status: 404 });
     }
 
     // 🔹 요청 바디 파싱
@@ -24,9 +30,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ success: false, error: "필수 값이 누락되었습니다." }, { status: 400 });
     }
 
-    // 🔹 DTO 생성 (characterId는 로그인한 유저의 ID로 설정)
+    // 🔹 DTO 생성 (캐릭터 ID를 정확히 사용)
     const dto: CreateQuestDTO = {
-      characterId: userId, // 로그인한 유저의 ID 사용
+      characterId: character.id,
       name,
       tagged,
       isWeekly,

--- a/application/usecases/auth/SignInUsecase.ts
+++ b/application/usecases/auth/SignInUsecase.ts
@@ -22,6 +22,9 @@ export class SignInUsecase {
         }
 
         const { password } = user;
+        if (!password) {
+            throw new LoginError("INVALID_PASSWORD", "비밀번호가 올바르지 않습니다.");
+        }
         const isPasswordValid = await this.verifyPasswordUsecase.execute(request.password, password);
         
         if (!isPasswordValid) {

--- a/application/usecases/auth/SignUpUsecase.ts
+++ b/application/usecases/auth/SignUpUsecase.ts
@@ -20,6 +20,8 @@ export class SignUpUsecase {
       email: request.email,
       password: request.password,
       nickname: request.nickname,
+      provider: "email",
+      providerId: null,
     });
 
     const today = new Date();

--- a/infrastructure/rate-limiter.ts
+++ b/infrastructure/rate-limiter.ts
@@ -1,0 +1,64 @@
+import redisClient from "@/infrastructure/databases/redis/server";
+
+interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  retryAfterSeconds: number;
+}
+
+/**
+ * Redis 기반 Sliding Window Rate Limiter
+ * IP별로 일정 시간 내 최대 요청 수를 제한한다.
+ */
+export async function checkRateLimit(
+  key: string,
+  maxRequests: number,
+  windowSeconds: number
+): Promise<RateLimitResult> {
+  const redisKey = `rate_limit:${key}`;
+  const now = Date.now();
+  const windowStart = now - windowSeconds * 1000;
+
+  const pipeline = redisClient.pipeline();
+  // 윈도우 밖의 오래된 요청 기록 제거
+  pipeline.zremrangebyscore(redisKey, 0, windowStart);
+  // 현재 요청 추가
+  pipeline.zadd(redisKey, now, `${now}:${Math.random()}`);
+  // 현재 윈도우 내 요청 수 조회
+  pipeline.zcard(redisKey);
+  // TTL 설정 (윈도우 시간 후 자동 삭제)
+  pipeline.expire(redisKey, windowSeconds);
+
+  const results = await pipeline.exec();
+  const requestCount = (results?.[2]?.[1] as number) ?? 0;
+
+  if (requestCount > maxRequests) {
+    // 가장 오래된 요청의 만료 시점 계산
+    const oldestEntries = await redisClient.zrange(redisKey, 0, 0, "WITHSCORES");
+    const oldestTimestamp = oldestEntries.length >= 2 ? parseInt(oldestEntries[1], 10) : now;
+    const retryAfter = Math.ceil((oldestTimestamp + windowSeconds * 1000 - now) / 1000);
+
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterSeconds: Math.max(retryAfter, 1),
+    };
+  }
+
+  return {
+    allowed: true,
+    remaining: maxRequests - requestCount,
+    retryAfterSeconds: 0,
+  };
+}
+
+/**
+ * IP 추출 헬퍼
+ */
+export function getClientIp(headers: Headers): string {
+  return (
+    headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    headers.get("x-real-ip") ||
+    "unknown"
+  );
+}

--- a/infrastructure/repositories/PriUserRepository.ts
+++ b/infrastructure/repositories/PriUserRepository.ts
@@ -48,12 +48,15 @@ export class PriUserRepository implements IUserRepository {
   }
 
   async verifyPassword(user: User, password: string): Promise<boolean> {
-    return await bcrypt.compare(password, user.password);
+    if (!user.password) return false;
+    return await bcrypt.compare(password, user.password) as boolean;
   }
 
   async create(data: Omit<User, 'id' | 'createdAt' | 'updatedAt'>): Promise<User> {
     return await this.prisma.$transaction(async (tx) => {
-      const hashedPassword = await bcrypt.hash(data.password, 10);
+      const hashedPassword = data.password
+        ? (await bcrypt.hash(data.password, 10) as string)
+        : null;
 
       const newUser = await tx.user.create({
         data: {
@@ -61,6 +64,8 @@ export class PriUserRepository implements IUserRepository {
           email: data.email,
           password: hashedPassword,
           nickname: data.nickname,
+          provider: data.provider,
+          providerId: data.providerId,
         },
       });
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
 import { getUserFromCookie } from "@/utils/auth";
-import { decodeJwt } from "jose";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -39,25 +38,10 @@ export async function middleware(request: NextRequest) {
     // refreshToken만 존재하고 accessToken이 없는 경우 루트로 리다이렉트
 
     try {
-      const decoded = decodeJwt(refreshToken.value) as { id?: string; loginId?: string };
-
-      // accessToken 존재 여부 헤더 설정
+      // refreshToken 존재 여부만 헤더에 설정 (토큰 값 자체는 절대 노출하지 않음)
       response.headers.set("X-Has-AccessToken", String(hasAccessToken));
-      // refreshToken 존재 여부 헤더 설정
       response.headers.set("X-Has-RefreshToken", String(hasRefreshToken));
-      
-      // refreshToken 값 자체를 헤더에 설정
-      response.headers.set("X-RefreshToken", refreshToken.value);
-
-      // 디코드된 객체에서 id와 loginId를 헤더에 설정
-      if (decoded?.id) {
-        response.headers.set("X-Id", decoded.id);
-      }
-      if (decoded?.loginId) {
-        response.headers.set("X-LoginId", decoded.loginId);
-      }
     } catch {
-      // 디코드 실패 시 기본 응답 반환
       return NextResponse.next();
     }
   } else {
@@ -65,11 +49,7 @@ export async function middleware(request: NextRequest) {
     response.headers.set("X-Has-RefreshToken", String(hasRefreshToken));
   }
 
-  // 응답 내용을 클라이언트로 반환
   return response;
-
-  // 인증되지 않은 경우 그대로 진행 (클라이언트에서 처리)
-  return NextResponse.next();
 }
 
 export const config = {


### PR DESCRIPTION
## 📝작업 내용

### 1. 카카오 OAuth CSRF 보호 및 로그인 Rate Limiting
- 카카오 OAuth에 `state` 파라미터 기반 CSRF 검증 추가 (32바이트 랜덤 토큰 → HttpOnly 쿠키 저장 → 콜백에서 비교)
- 로그인(`/api/auth/signin`), 카카오 로그인(`/api/auth/kakao`) API에 Redis 기반 Sliding Window Rate Limiting 적용 (60초당 5회)
- `infrastructure/rate-limiter.ts` 신규 추가

### 2. 인증 API Rate Limiting 확대 및 토큰 노출 방지
- **Refresh Token 헤더 노출 제거**: middleware에서 `X-RefreshToken`, `X-Id`, `X-LoginId` 헤더를 통해 토큰이 그대로 노출되던 문제 수정
- **Access Token body 반환 제거**: signin 응답 JSON에서 accessToken 제거 (HttpOnly 쿠키로만 전달)
- 보호되지 않던 6개 API에 Rate Limiting 추가:
  - `signup` (60초당 3회), `send-signup-email` (120초당 3회), `check-verify-code` (300초당 5회)
  - `check-exist-email`, `check-exist-login-id` (60초당 10회), `find-login-id` (60초당 5회)
- 에러 응답에서 `error.message` 직접 반환 → 고정 메시지로 변경 (내부 정보 노출 방지)
- signup 쿠키에 `sameSite: "strict"` 누락 수정

### 3. 카카오 소셜 로그인 시 닉네임 입력 단계 추가
- **기존 유저**: 기존대로 바로 로그인 → `/play/character`
- **신규 유저**: 카카오 인증 데이터를 `kakao_pending` 쿠키에 임시 저장(5분 만료) → `/signup?provider=kakao`로 리다이렉트 → 닉네임 입력 후 가입 완료
- 카카오 가입 전용 API 신규 추가 (`/api/auth/kakao/signup`)
- signup 페이지에 카카오 모드 추가 (닉네임 필드만 표시, 아이디/이메일/비밀번호/인증 숨김)

### 4. 타입 에러 수정
- `SignInUsecase`: 소셜 로그인 유저(password null) 비밀번호 로그인 시도 시 예외 처리
- `SignUpUsecase`: `create()` 호출 시 `provider`/`providerId` 필드 누락 수정
- `PriUserRepository`: password nullable 처리 (null 체크, 조건부 해싱, provider 필드 추가)

### 5. 퀘스트 생성 characterId 버그 수정
- `userId`를 `characterId`로 잘못 사용하던 문제 수정 → `character.id`를 정확히 조회하여 사용

<br>

## 💬리뷰 요구사항(선택)

- `middleware.ts`에서 Refresh Token 헤더 노출을 제거하면서 `decodeJwt`도 함께 제거했는데, 기존에 `X-Id`/`X-LoginId` 헤더를 사용하던 클라이언트 코드가 있다면 영향 확인
- 카카오 신규 가입 흐름에서 `kakao_pending` 쿠키(5분 만료)가 적절한지, 쿠키 대신 다른 방식(Redis 세션 등)이 더 나을지 
- Rate Limiting 수치(signup 3회/60초, verify-code 5회/300초 등)가 실제 사용 패턴에 적합한지