### PR TITLE
fix(quest): CreateQuestUsecase에 difficulty 기본값 전달

### DIFF
--- a/application/usecases/quest/CreateQuestUsecase.ts
+++ b/application/usecases/quest/CreateQuestUsecase.ts
@@ -23,6 +23,7 @@ export class CreateQuestUseCase {
       name: dto.name,
       tagged: dto.tagged,
       isWeekly: dto.isWeekly,
+      difficulty: dto.difficulty ?? "normal",
       expiredAt,
       createdAt: new Date(),
       updatedAt: new Date(),


### PR DESCRIPTION
Prisma 스키마의 Quest.difficulty는 @default("normal")이지만 
TypeScript 타입 레벨에선 required라 프로덕션 빌드에서 타입 에러 발생.
DTO의 difficulty를 전달하거나 없으면 "normal" 기본값 사용.
