### PR TITLE
fix(ci/redis): Upstash 환경변수명 정정 + 명시적 검증

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Set test environment variables
         run: |
           echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" > .env
-          echo "REDIS_URL=${{ secrets.REDIS_URL }}" >> .env
+          echo "UPSTASH_REDIS_REST_URL=${{ secrets.UPSTASH_REDIS_REST_URL }}" >> .env
+          echo "UPSTASH_REDIS_REST_TOKEN=${{ secrets.UPSTASH_REDIS_REST_TOKEN }}" >> .env
           echo "NODE_ENV=test" >> .env
           echo "NEXT_PUBLIC_GA_ID=${{ secrets.NEXT_PUBLIC_GA_ID }}" >> .env
 
@@ -75,7 +76,8 @@ jobs:
           cat > .env <<EOF
           # DB / Cache
           DATABASE_URL=${{ secrets.DATABASE_URL }}
-          REDIS_URL=${{ secrets.REDIS_URL }}
+          UPSTASH_REDIS_REST_URL=${{ secrets.UPSTASH_REDIS_REST_URL }}
+          UPSTASH_REDIS_REST_TOKEN=${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
 
           # JWT
           ACCESS_TOKEN_SECRET=${{ secrets.ACCESS_TOKEN_SECRET }}

--- a/infrastructure/databases/redis/server.ts
+++ b/infrastructure/databases/redis/server.ts
@@ -12,9 +12,18 @@ import { Redis } from "@upstash/redis";
  *
  * 둘 다 설정 안 돼 있으면 생성자에서 throw.
  */
-const redisClient = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-});
+const url = process.env.UPSTASH_REDIS_REST_URL;
+const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+if (!url || !token) {
+  // 빈 url 로 init 되면 fetch 시 "/pipeline" 만 사용해 URL 파싱 에러가 나며
+  // 모든 redis 호출 경로(예: rate-limiter, auth)가 500 으로 깨진다.
+  // 빠른 진단 위해 init 시점에 명확히 throw.
+  throw new Error(
+    "[redis] UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN 환경변수가 비어있습니다. .env 또는 GitHub Secrets 확인 필요."
+  );
+}
+
+const redisClient = new Redis({ url, token });
 
 export default redisClient;


### PR DESCRIPTION
## 📝 작업 내용
- CI: cron 리포 default 브랜치 `main` → `develop` 정정
- CI: Upstash Redis 환경변수명 정정 (`REDIS_URL` → `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`)
- 빌드 lint 에러 정리 (미사용 변수 제거)