### PR TITLE
fix: 인증 known issues 정리 (refresh token TTL/캐스팅 버그/Redis key prefix)

### DIFF
--- a/application/usecases/auth/GenerateRefreshTokenUsecase.ts
+++ b/application/usecases/auth/GenerateRefreshTokenUsecase.ts
@@ -14,7 +14,7 @@ export class GenerateRefreshTokenUsecase {
         const iat = Math.floor(Date.now() / 1000);
         const refreshToken = await new SignJWT({ id: user.id, loginId: user.loginId, iat })
             .setProtectedHeader({ alg: "HS256" })
-            .setExpirationTime(process.env.REFRESH_TOKEN_EXPIRES!) // 예: "7d"
+            .setExpirationTime(process.env.REFRESH_TOKEN_EXPIRES!)
             .sign(secret);
         await this.repository.saveRefreshToken(user.loginId, refreshToken);
         return refreshToken;

--- a/infrastructure/repositories/RdAuthenticationRepository.ts
+++ b/infrastructure/repositories/RdAuthenticationRepository.ts
@@ -2,17 +2,32 @@
 import { IRdAuthenticationRepository } from '@/domain/repositories/IRdAuthenticationRepository';
 import redisClient from '@/infrastructure/databases/redis/server';
 
+const REFRESH_KEY_PREFIX = 'refresh:';
+
+// "2592000s" / "30d" / "60m" / "1h" → 초(seconds)
+function parseExpiryToSeconds(exp: string): number {
+    const match = exp.match(/^(\d+)([smhd])$/);
+    if (!match) throw new Error(`Invalid REFRESH_TOKEN_EXPIRES format: ${exp}`);
+    const value = parseInt(match[1], 10);
+    const unit = match[2];
+    const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+    return value * multipliers[unit];
+}
+
+// JWT 만료(REFRESH_TOKEN_EXPIRES)와 Redis TTL을 일치시켜 mismatch 제거
+const REFRESH_TTL_SECONDS = parseExpiryToSeconds(process.env.REFRESH_TOKEN_EXPIRES ?? '2592000s');
+
 export class RdAuthenticationRepository implements IRdAuthenticationRepository {
     async saveRefreshToken(userId: string, refreshToken: string): Promise<void> {
-        await redisClient.set(userId, refreshToken, { ex: 86400 }); // 24시간 만료
+        await redisClient.set(REFRESH_KEY_PREFIX + userId, refreshToken, { ex: REFRESH_TTL_SECONDS });
     }
 
     async getRefreshToken(userId: string): Promise<string | null> {
-        return await redisClient.get<string>(userId);
+        return await redisClient.get<string>(REFRESH_KEY_PREFIX + userId);
     }
 
     async deleteRefreshToken(userId: string): Promise<void> {
-        await redisClient.del(userId);
+        await redisClient.del(REFRESH_KEY_PREFIX + userId);
     }
 
     // Access Token은 Redis에 저장하지 않습니다.

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -41,8 +41,8 @@ export async function getUserFromCookie(
 
     // 새로운 Access Token 생성
     const newAccessToken = await generateAccessTokenUsecase.execute({
-      id: refreshPayload.id as number, // id는 refreshPayload에서 추출
-      loginId: refreshPayload.id as string, // loginId는 refreshPayload에서 추출
+      id: refreshPayload.id as number,
+      loginId: refreshPayload.loginId as string,
     });
 
     // 새 Access Token을 쿠키에 설정한 응답 생성


### PR DESCRIPTION


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- utils/auth.ts: refresh로 access token 재발급 시 loginId 자리에 .id 가 잘못 들어가던 버그 수정 (.loginId 로 교정)
- RdAuthenticationRepository: Redis TTL 24h 하드코딩을 REFRESH_TOKEN_EXPIRES env 파싱으로 변경하여 JWT 만료(30d)와 일치
- RdAuthenticationRepository: Redis 키에 'refresh:' prefix 추가로 다른 키 충돌 방지
- GenerateRefreshTokenUsecase: 실제 값과 다른 stale 주석 제거

<br>