### PR TITLE
feat: 이용약관/개인정보 처리방침 페이지 + 회원가입 동의 플로우 추가

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -270,6 +270,19 @@ const SignUp = () => {
   /* submit 시 닉네임 및 이메일 공란일 경우 설정 끝 */
 
 
+  /* 약관 동의 시작 */
+  const [agreeTerms, setAgreeTerms] = useState<boolean>(false);
+  const [agreePrivacy, setAgreePrivacy] = useState<boolean>(false);
+  const [showAgreementMessage, setShowAgreementMessage] = useState<boolean>(false);
+
+  const handleAgreeAllChange = (checked: boolean) => {
+    setAgreeTerms(checked);
+    setAgreePrivacy(checked);
+    if (checked) setShowAgreementMessage(false);
+  };
+  /* 약관 동의 끝 */
+
+
   // Input 값 비울 경우 하단 표시 메시지 초기화 (통합 관리)
   const handleLoginIdChange = () => {
     setLoginIdExists(null);
@@ -335,6 +348,13 @@ const SignUp = () => {
       setShowVerificationMessage(false); // 인증 완료 시 메시지 숨김
     }
   
+    // 약관 동의 체크
+    if (!agreeTerms || !agreePrivacy) {
+      setShowAgreementMessage(true);
+      return;
+    }
+    setShowAgreementMessage(false);
+
     // 모든 입력값과 조건을 한 번에 체크
     if (
       !loginId || !email || !nickname || !password || !confirmPasswordValue ||
@@ -382,6 +402,12 @@ const SignUp = () => {
 
     setNicknameEmpty(!nickname);
     if (!nickname) return;
+
+    if (!agreeTerms || !agreePrivacy) {
+      setShowAgreementMessage(true);
+      return;
+    }
+    setShowAgreementMessage(false);
 
     try {
       const response = await fetch('/api/auth/kakao/signup', {
@@ -537,6 +563,66 @@ const SignUp = () => {
           </div>
         </>
       )}
+
+      {/* 약관 동의 */}
+      <div className="mt-2 border-2 border-[#4A3F2F] bg-[#fffdf2] p-3 text-[13px] text-[#4A3F2F]">
+        <label className="flex items-center gap-2 cursor-pointer mb-2 pb-2 border-b border-[#c9b178] font-bold">
+          <input
+            type="checkbox"
+            checked={agreeTerms && agreePrivacy}
+            onChange={(e) => handleAgreeAllChange(e.target.checked)}
+            className="w-4 h-4 cursor-pointer"
+          />
+          <span>전체 동의</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer mb-1.5">
+          <input
+            type="checkbox"
+            checked={agreeTerms}
+            onChange={(e) => {
+              setAgreeTerms(e.target.checked);
+              if (e.target.checked && agreePrivacy) setShowAgreementMessage(false);
+            }}
+            className="w-4 h-4 cursor-pointer"
+          />
+          <span className="flex-1">[필수] 이용약관 동의</span>
+          <a
+            href="/terms"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px] underline text-[#6e5a37]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            보기
+          </a>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={agreePrivacy}
+            onChange={(e) => {
+              setAgreePrivacy(e.target.checked);
+              if (e.target.checked && agreeTerms) setShowAgreementMessage(false);
+            }}
+            className="w-4 h-4 cursor-pointer"
+          />
+          <span className="flex-1">[필수] 개인정보 처리방침 동의</span>
+          <a
+            href="/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px] underline text-[#6e5a37]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            보기
+          </a>
+        </label>
+        {showAgreementMessage && (
+          <span className="block mt-2 text-sm text-[#A72F35]">
+            필수 약관에 동의해 주세요.
+          </span>
+        )}
+      </div>
 
       {/* 버튼 */}
       <div className="mt-6">

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function PrivacyPage() {
+  const router = useRouter();
+
+  return (
+    <div
+      className="flex flex-col min-h-screen overflow-hidden"
+      style={{
+        backgroundImage: "url('/images/backgrounds/bg_01.png')",
+        backgroundSize: "100% 100%",
+        backgroundRepeat: "no-repeat",
+      }}
+    >
+      <div className="flex items-center px-4 pt-6 pb-4">
+        <button
+          onClick={() => router.back()}
+          className="text-white text-2xl cursor-pointer"
+          aria-label="뒤로가기"
+        >
+          ←
+        </button>
+        <h1 className="flex-1 text-center text-xl font-galmuri11-bold text-white mr-6">
+          개인정보 처리방침
+        </h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-6 pb-10">
+        <article className="mx-auto max-w-[640px] bg-[#fffdf2] border-[3px] border-[#4A3F2F] p-6 text-[13px] leading-7 text-[#4A3F2F] shadow-[4px_4px_0_#c9b178]">
+          <p className="mb-4 text-[12px] text-[#6e5a37]">
+            시행일: 2026년 5월 2일
+          </p>
+
+          <p className="mb-4">
+            TODO HUNTER(이하 &quot;서비스&quot;)는 「개인정보 보호법」 및 관련
+            법령을 준수하며, 정보주체의 개인정보 및 권익을 보호하기 위해 다음과
+            같은 처리방침을 두고 있습니다.
+          </p>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">1. 개인정보의 처리 목적</h2>
+          <p className="mb-2">서비스는 다음의 목적을 위해 개인정보를 처리합니다.</p>
+          <ul className="list-disc list-inside mb-4 ml-1 space-y-0.5">
+            <li>회원 식별 및 본인 확인</li>
+            <li>서비스 제공 및 운영, 콘텐츠 개인화</li>
+            <li>회원 가입 의사의 확인 및 부정 이용 방지</li>
+            <li>고객 문의 응대 및 공지사항 전달</li>
+            <li>서비스 개선을 위한 통계 분석</li>
+          </ul>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">2. 처리하는 개인정보 항목</h2>
+          <p className="mb-1 font-bold">가. 필수 수집 항목</p>
+          <ul className="list-disc list-inside mb-3 ml-1 space-y-0.5">
+            <li>이메일 가입: 로그인 아이디, 이메일, 비밀번호(암호화 저장), 닉네임</li>
+            <li>카카오 소셜 로그인: 카카오 회원번호(provider ID), 이메일, 닉네임</li>
+          </ul>
+          <p className="mb-1 font-bold">나. 자동 수집 항목</p>
+          <ul className="list-disc list-inside mb-4 ml-1 space-y-0.5">
+            <li>접속 IP 주소(이용 제한 및 부정 이용 방지 목적)</li>
+            <li>인증 쿠키(Access Token, Refresh Token)</li>
+            <li>서비스 이용 기록(퀘스트 생성/완료, 로그인 기록 등)</li>
+            <li>오류 로그(서비스 안정성 모니터링)</li>
+          </ul>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">3. 개인정보의 보유 및 이용 기간</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>회원의 개인정보는 회원 탈퇴 시까지 보유합니다.</li>
+            <li>회원 탈퇴 시 모든 개인정보는 지체 없이 파기됩니다. 단, 관련 법령에서 보존 의무를 부과하는 경우 해당 기간 동안 별도로 보관합니다.</li>
+            <li>1년 이상 서비스 이용 기록이 없는 휴면 계정은 별도 통지 후 분리 보관 또는 삭제할 수 있습니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">4. 개인정보의 제3자 제공</h2>
+          <p className="mb-4">
+            서비스는 정보주체의 동의 없이 개인정보를 제3자에게 제공하지 않습니다.
+            법령에 의한 경우 또는 수사기관의 적법한 요청이 있는 경우에 한하여
+            제공할 수 있습니다.
+          </p>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">5. 개인정보 처리위탁</h2>
+          <p className="mb-2">서비스는 원활한 운영을 위하여 다음과 같이 개인정보 처리 업무를 위탁하고 있습니다.</p>
+          <div className="mb-4 border border-[#6e5a37] text-[12px]">
+            <table className="w-full">
+              <thead className="bg-[#e8d49b]">
+                <tr>
+                  <th className="border border-[#6e5a37] p-2 text-left">수탁자</th>
+                  <th className="border border-[#6e5a37] p-2 text-left">위탁 업무</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="border border-[#6e5a37] p-2">Kakao Corp.</td>
+                  <td className="border border-[#6e5a37] p-2">소셜 로그인 인증</td>
+                </tr>
+                <tr>
+                  <td className="border border-[#6e5a37] p-2">Upstash, Inc.</td>
+                  <td className="border border-[#6e5a37] p-2">인증 토큰 캐시 저장 (Redis)</td>
+                </tr>
+                <tr>
+                  <td className="border border-[#6e5a37] p-2">Cloudflare, Inc.</td>
+                  <td className="border border-[#6e5a37] p-2">정적 파일 저장 및 네트워크 라우팅 (R2 / Tunnel)</td>
+                </tr>
+                <tr>
+                  <td className="border border-[#6e5a37] p-2">Functional Software, Inc. (Sentry)</td>
+                  <td className="border border-[#6e5a37] p-2">오류 모니터링 및 성능 추적</td>
+                </tr>
+                <tr>
+                  <td className="border border-[#6e5a37] p-2">[__SMTP_제공자__]</td>
+                  <td className="border border-[#6e5a37] p-2">회원가입 인증 메일 발송</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">6. 개인정보의 국외 이전</h2>
+          <p className="mb-2">
+            위 처리위탁 업체 중 일부는 해외 사업자이며, 정보주체의 개인정보는
+            해당 사업자의 서버가 위치한 국외에 저장·처리될 수 있습니다.
+          </p>
+          <ul className="list-disc list-inside mb-4 ml-1 space-y-0.5 text-[12px]">
+            <li>이전 국가: 미국 등 (수탁자 인프라 위치에 따름)</li>
+            <li>이전 항목: 위 &quot;처리하는 개인정보 항목&quot;과 동일</li>
+            <li>이전 시점 및 방법: 서비스 이용 시점에 네트워크를 통해 이전</li>
+            <li>보유 및 이용 기간: 위탁 계약 종료 시 또는 회원 탈퇴 시까지</li>
+          </ul>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">7. 정보주체의 권리</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>정보주체는 언제든지 개인정보 열람·정정·삭제·처리정지를 요구할 수 있습니다.</li>
+            <li>회원 탈퇴를 통해 개인정보 삭제를 직접 요청할 수 있습니다.</li>
+            <li>위 권리 행사는 아래 개인정보 보호책임자에게 이메일 등으로 연락하여 신청할 수 있으며, 서비스는 지체 없이 조치합니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">8. 개인정보의 파기</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>보유 기간이 경과하거나 처리 목적이 달성된 개인정보는 지체 없이 파기합니다.</li>
+            <li>전자적 파일은 복구 불가능한 방법으로 영구 삭제하며, 종이 문서는 분쇄 또는 소각합니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">9. 개인정보의 안전성 확보 조치</h2>
+          <ul className="list-disc list-inside mb-4 ml-1 space-y-0.5">
+            <li>비밀번호의 일방향 암호화 저장(bcrypt)</li>
+            <li>인증 토큰의 HttpOnly 쿠키 저장 및 HTTPS 통신</li>
+            <li>접근 제어 및 권한 관리(API 라우트 보호)</li>
+            <li>비정상 접근 차단을 위한 Rate Limiting 적용</li>
+            <li>접속 기록의 보관 및 위변조 방지</li>
+          </ul>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">10. 쿠키의 사용</h2>
+          <p className="mb-4">
+            서비스는 회원 인증 상태 유지를 위해 HttpOnly 쿠키(Access Token,
+            Refresh Token)를 사용합니다. 회원은 브라우저 설정을 통해 쿠키 저장을
+            거부할 수 있으나, 이 경우 서비스의 이용이 제한될 수 있습니다.
+          </p>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">11. 개인정보 보호책임자</h2>
+          <div className="mb-4 border border-[#6e5a37] p-3 bg-[#f5e9c8] text-[12px]">
+            <p>성명: <span className="font-bold">박금정</span></p>
+            <p>직책: 개인정보 보호책임자</p>
+            <p>이메일: <span className="font-bold">yjjuc4109@gmail.com</span></p>
+          </div>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">12. 권익침해 구제 방법</h2>
+          <p className="mb-2">개인정보 침해 신고 및 상담은 아래 기관에 문의하실 수 있습니다.</p>
+          <ul className="list-disc list-inside mb-4 ml-1 space-y-0.5 text-[12px]">
+            <li>개인정보분쟁조정위원회 (privacy.go.kr / 1833-6972)</li>
+            <li>개인정보침해신고센터 (privacy.kisa.or.kr / 118)</li>
+            <li>대검찰청 사이버수사과 (spo.go.kr / 1301)</li>
+            <li>경찰청 사이버수사국 (ecrm.cyber.go.kr / 182)</li>
+          </ul>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">13. 처리방침의 변경</h2>
+          <p className="mb-4">
+            본 처리방침은 시행일로부터 적용되며, 법령 및 방침에 따른 변경사항이
+            있을 경우 시행 7일 전부터 서비스 내 공지를 통해 사전 안내합니다.
+          </p>
+
+          <p className="mt-6 text-[12px] text-[#6e5a37]">
+            본 처리방침은 2026년 5월 2일부터 시행됩니다.
+          </p>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function TermsPage() {
+  const router = useRouter();
+
+  return (
+    <div
+      className="flex flex-col min-h-screen overflow-hidden"
+      style={{
+        backgroundImage: "url('/images/backgrounds/bg_01.png')",
+        backgroundSize: "100% 100%",
+        backgroundRepeat: "no-repeat",
+      }}
+    >
+      <div className="flex items-center px-4 pt-6 pb-4">
+        <button
+          onClick={() => router.back()}
+          className="text-white text-2xl cursor-pointer"
+          aria-label="뒤로가기"
+        >
+          ←
+        </button>
+        <h1 className="flex-1 text-center text-xl font-galmuri11-bold text-white mr-6">
+          이용약관
+        </h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-6 pb-10">
+        <article className="mx-auto max-w-[640px] bg-[#fffdf2] border-[3px] border-[#4A3F2F] p-6 text-[13px] leading-7 text-[#4A3F2F] shadow-[4px_4px_0_#c9b178]">
+          <p className="mb-4 text-[12px] text-[#6e5a37]">
+            시행일: 2026년 5월 2일
+          </p>
+
+          <h2 className="mt-2 mb-2 text-[15px] font-bold">제1조 (목적)</h2>
+          <p className="mb-4">
+            본 약관은 TODO HUNTER(이하 &quot;서비스&quot;)가 제공하는 게이미피케이션
+            기반 할 일 관리 서비스의 이용과 관련하여 서비스 운영자(이하
+            &quot;운영자&quot;)와 회원 간의 권리, 의무 및 책임사항, 기타 필요한
+            사항을 규정함을 목적으로 합니다.
+          </p>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제2조 (정의)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>&quot;서비스&quot;란 운영자가 제공하는 TODO HUNTER 웹/모바일 애플리케이션 일체를 말합니다.</li>
+            <li>&quot;회원&quot;이란 본 약관에 동의하고 서비스에 가입하여 이용하는 자를 말합니다.</li>
+            <li>&quot;계정&quot;이란 회원의 식별과 서비스 이용을 위해 부여되는 로그인 아이디 또는 소셜 로그인 식별자를 말합니다.</li>
+            <li>&quot;인게임 자산&quot;이란 회원이 서비스 내에서 획득하는 경험치, 레벨, 칭호, 캐릭터 등 모든 가상 자산을 말합니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제3조 (약관의 효력 및 변경)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>본 약관은 회원이 동의함과 동시에 효력이 발생합니다.</li>
+            <li>운영자는 관련 법령을 위배하지 않는 범위에서 본 약관을 개정할 수 있으며, 변경 사항은 서비스 내 공지 또는 이메일 등의 방법으로 사전 공지합니다.</li>
+            <li>회원이 변경된 약관에 동의하지 않는 경우 회원 탈퇴를 통해 이용계약을 해지할 수 있습니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제4조 (회원가입)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>회원가입은 본 약관 및 개인정보 처리방침에 동의한 후 이용신청을 함으로써 성립합니다.</li>
+            <li>만 14세 미만의 아동은 본 서비스에 가입할 수 없습니다.</li>
+            <li>운영자는 다음 각 호에 해당하는 경우 가입 신청을 거절하거나 사후 해지할 수 있습니다.
+              <ul className="list-disc list-inside ml-4 mt-1 space-y-0.5">
+                <li>타인의 명의 또는 정보를 도용한 경우</li>
+                <li>허위 정보를 기재한 경우</li>
+                <li>관련 법령 또는 본 약관을 위반한 경우</li>
+              </ul>
+            </li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제5조 (계정 관리)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>회원은 자신의 계정과 비밀번호를 직접 관리할 책임이 있으며, 이를 제3자에게 양도하거나 공유할 수 없습니다.</li>
+            <li>계정의 도용 또는 부정 사용이 의심되는 경우 즉시 운영자에게 통지해야 합니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제6조 (서비스의 제공 및 변경)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>서비스는 연중무휴, 1일 24시간 제공을 원칙으로 합니다. 단, 시스템 점검·교체·고장, 통신 두절 등 부득이한 사유가 있는 경우 일시 중단될 수 있습니다.</li>
+            <li>운영자는 서비스의 일부 또는 전체를 운영상 또는 기술상의 필요에 따라 변경할 수 있으며, 변경 시 사전 공지합니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제7조 (인게임 자산)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>인게임 자산은 서비스 내 이용에 한하며, 현금 또는 그에 준하는 가치로 환전 또는 환불되지 않습니다.</li>
+            <li>회원의 계정 탈퇴, 서비스 종료, 약관 위반에 따른 이용 제한 등의 경우 인게임 자산은 소멸되며 보상되지 않습니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제8조 (회원의 의무)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>회원은 다음 행위를 하여서는 안 됩니다.
+              <ul className="list-disc list-inside ml-4 mt-1 space-y-0.5">
+                <li>타인의 정보 도용</li>
+                <li>서비스의 정상적인 운영을 방해하는 행위</li>
+                <li>비정상적인 방법(매크로, 자동화 도구 등)으로 서비스를 이용하는 행위</li>
+                <li>관련 법령에 위반되는 행위</li>
+              </ul>
+            </li>
+            <li>회원이 본 조를 위반하는 경우 운영자는 사전 통지 없이 이용을 제한하거나 계정을 해지할 수 있습니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제9조 (계약 해지 및 이용 제한)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>회원은 언제든지 서비스 내 회원 탈퇴 기능을 통해 이용계약을 해지할 수 있습니다.</li>
+            <li>탈퇴 시 본인의 모든 데이터(퀘스트, 캐릭터, 인게임 자산 등)는 삭제되며 복구되지 않습니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제10조 (면책)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>운영자는 천재지변, 전쟁, 통신 두절, 해킹 등 운영자의 합리적인 통제를 벗어난 사유로 인한 서비스 중단에 대하여 책임지지 않습니다.</li>
+            <li>운영자는 회원이 서비스를 통해 얻은 정보 또는 자료의 정확성·완전성에 대하여 보증하지 않습니다.</li>
+            <li>회원 간 또는 회원과 제3자 사이에 발생한 분쟁에 대하여 운영자는 개입할 의무가 없으며, 그로 인한 손해를 배상할 책임이 없습니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제11조 (분쟁 해결 및 재판 관할)</h2>
+          <ol className="list-decimal list-inside mb-4 space-y-1">
+            <li>본 약관 및 서비스 이용과 관련하여 발생한 분쟁은 대한민국 법령에 따라 해결합니다.</li>
+            <li>관할 법원은 민사소송법 등 관련 법령에서 정한 법원으로 합니다.</li>
+          </ol>
+
+          <h2 className="mt-4 mb-2 text-[15px] font-bold">제12조 (문의)</h2>
+          <p className="mb-4">
+            서비스 이용 관련 문의는 다음 연락처로 가능합니다.<br />
+            이메일: <span className="font-bold">yjjuc4109@gmail.com</span>
+          </p>
+
+          <p className="mt-6 text-[12px] text-[#6e5a37]">
+            본 약관은 2026년 5월 2일부터 시행됩니다.
+          </p>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/components/common/NavigationWrapper.tsx
+++ b/components/common/NavigationWrapper.tsx
@@ -26,7 +26,7 @@ export default function NavigationWrapper() {
   }, [pathname]);
 
   // 네비게이션을 숨길 페이지 목록
-  const hiddenRoutes = ["/", "/signin", "/signup", "/findid", "/findpw", "/error", "/not-found"];
+  const hiddenRoutes = ["/", "/signin", "/signup", "/findid", "/findpw", "/terms", "/privacy", "/error", "/not-found"];
   const shouldHideNavigation = hiddenRoutes.includes(pathname) || pathname.startsWith("/tools") || isErrorPage;
 
   if (shouldHideNavigation) return null; // 네비게이션 숨김

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,18 @@
 import { NextResponse, NextRequest } from "next/server";
 import { getUserFromCookie } from "@/utils/auth";
 
-// 공개 경로 (인증 불필요) — Fail-safe default: 이 Set에 없으면 모두 인증 필수
-const PUBLIC_PATHS = new Set<string>([
+// 인증 페이지 — 이미 로그인된 유저는 게임으로 리다이렉트
+const AUTH_REDIRECT_PATHS = new Set<string>([
   "/",
   "/signin",
   "/signup",
   "/findid",
+]);
+
+// 누구나 접근 가능한 정적 정보 페이지 (로그인 여부와 무관)
+const OPEN_PATHS = new Set<string>([
+  "/terms",
+  "/privacy",
 ]);
 
 // 차단 경로 (사용 중단된 페이지)
@@ -25,14 +31,17 @@ export async function middleware(request: NextRequest) {
   // 토큰 검증 (+ 만료 시 자동 갱신)
   const { user, response: refreshedResponse } = await getUserFromCookie(request);
 
-  // 공개 경로 처리
-  if (PUBLIC_PATHS.has(pathname)) {
-    // 이미 로그인된 사용자는 게임으로 리다이렉트
+  // 누구나 열람 가능한 페이지: 통과
+  if (OPEN_PATHS.has(pathname)) {
+    return refreshedResponse ?? NextResponse.next();
+  }
+
+  // 인증 페이지: 로그인 유저는 게임으로, 비로그인 유저는 토큰 상태 헤더 노출
+  if (AUTH_REDIRECT_PATHS.has(pathname)) {
     if (user) {
       return NextResponse.redirect(new URL("/play/character", request.url));
     }
 
-    // 미로그인 사용자: 토큰 상태를 헤더로 노출 (랜딩 페이지 useEffect에서 사용)
     const hasAccessToken = !!request.cookies.get("accessToken");
     const hasRefreshToken = !!request.cookies.get("refreshToken");
     const response = refreshedResponse ?? NextResponse.next();


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- /terms, /privacy 페이지 신설 (한국 개인정보보호법 + KISA 표준 양식 기반 템플릿)
- middleware: 누구나 열람 가능한 OPEN_PATHS 분리 → 로그인 유저도 약관 페이지 접근 가능
- 회원가입 폼: 이용약관/개인정보 처리방침 필수 동의 체크박스 추가, 미동의 시 가입 차단 (이메일/카카오 가입 모두 적용)
- NavigationWrapper: /terms, /privacy 진입 시 하단 네비 숨김
<br>