### PR TITLE
fix: 회원가입 API가 실패하면 상태코드별 메시지를 표시하고 즉시 중단

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -274,6 +274,8 @@ const SignUp = () => {
   const [agreeTerms, setAgreeTerms] = useState<boolean>(false);
   const [agreePrivacy, setAgreePrivacy] = useState<boolean>(false);
   const [showAgreementMessage, setShowAgreementMessage] = useState<boolean>(false);
+  const [isSigningUp, setIsSigningUp] = useState<boolean>(false);
+  const [signupErrorMessage, setSignupErrorMessage] = useState<string>("");
 
   const handleAgreeAllChange = (checked: boolean) => {
     setAgreeTerms(checked);
@@ -308,7 +310,30 @@ const SignUp = () => {
 
 
   /* 가입 시작 */
+  const getSignupErrorMessage = (status: number, serverMessage?: string) => {
+    if (serverMessage) return serverMessage;
+
+    switch (status) {
+      case 400:
+        return "입력값을 확인해 주세요.";
+      case 403:
+        return "이메일 인증을 완료한 뒤 다시 시도해 주세요.";
+      case 409:
+        return "이미 가입된 아이디 또는 이메일입니다.";
+      case 429:
+        return "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.";
+      case 500:
+        return "서버 오류로 회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.";
+      case 503:
+        return "가입은 완료됐지만 자동 로그인에 실패했습니다. 로그인 화면에서 다시 로그인해 주세요.";
+      default:
+        return "회원가입에 실패했습니다. 잠시 후 다시 시도해 주세요.";
+    }
+  };
+
   const handleSignUp = async () => {
+    if (isSigningUp) return;
+
     const loginId = loginIdRef.current?.value;
     const email = emailRef.current?.value;
     const nickname = nicknameRef.current?.value;
@@ -366,6 +391,9 @@ const SignUp = () => {
       return; // 하나라도 실패하면 submit하지 않음
     }
 
+    setSignupErrorMessage("");
+    setIsSigningUp(true);
+
     try {
       const response = await fetch('/api/auth/signup', {
         method: 'POST',
@@ -374,18 +402,35 @@ const SignUp = () => {
         credentials: "include", // 쿠키 포함
       });
       if (!response.ok) {
-        throw new Error("Network response was not ok");
+        const data = await response.json().catch(() => null);
+        const message = getSignupErrorMessage(response.status, data?.error);
+        setSignupErrorMessage(message);
+        alert(message);
+        return;
       }
       // const data = await response.json(); // 회원가입 정보 클라이언트 측에 로그로 표시
       // console.log(data); // 회원가입 정보 클라이언트 측에 로그로 표시
     } catch (error) {
       console.error("Error signing up:", error);
+      const message = "네트워크 오류로 회원가입에 실패했습니다. 연결 상태를 확인한 뒤 다시 시도해 주세요.";
+      setSignupErrorMessage(message);
+      alert(message);
+      return;
+    } finally {
+      setIsSigningUp(false);
     }
 
     alert("가입이 완료되었습니다!");
 
     // 회원가입 성공 시 fetchUser 호출 후 리디렉션
-    await fetchUser();
+    try {
+      await fetchUser();
+    } catch (error) {
+      console.error("Error fetching user after signup:", error);
+      alert("회원가입은 완료됐지만 사용자 정보를 불러오지 못했습니다. 로그인 후 다시 이용해 주세요.");
+      router.push("/signin");
+      return;
+    }
 
     // // 가입 성공 시 로그인 페이지로 이동
     // router.push("/signin");
@@ -628,7 +673,15 @@ const SignUp = () => {
       {/* 버튼 */}
       <div className="mt-6">
         <Button className="w-full max-w-none" state="primary" size="L"
-          onClick={isKakao ? handleKakaoSignUp : handleSignUp}>회원가입하기</Button>
+          disabled={isSigningUp}
+          onClick={isKakao ? handleKakaoSignUp : handleSignUp}>
+          {isSigningUp ? "가입 중..." : "회원가입하기"}
+        </Button>
+        {signupErrorMessage && (
+          <span className="block mt-2 text-sm text-[#A72F35]">
+            {signupErrorMessage}
+          </span>
+        )}
       </div>
 
       </div>

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -6,10 +6,29 @@ import { PriCharacterRepository, PriStatusRepository, PriUserRepository } from "
 import { RdAuthenticationRepository } from "@/infrastructure/repositories/RdAuthenticationRepository";
 import { RdVerificationRepository } from "@/infrastructure/repositories/RdVerificationRepository";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 import { NextRequest, NextResponse } from "next/server";
 import { checkRateLimit, getClientIp } from "@/infrastructure/rate-limiter";
 
 const SIGNUP_RATE_LIMIT = { maxRequests: 3, windowSeconds: 60 };
+
+function getDuplicateSignupMessage(error: unknown) {
+    if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+    ) {
+        const target = Array.isArray(error.meta?.target) ? error.meta.target : [];
+        if (target.includes("login_id") || target.includes("loginId")) {
+            return "이미 가입된 아이디입니다.";
+        }
+        if (target.includes("email")) {
+            return "이미 가입된 이메일입니다.";
+        }
+        return "이미 가입된 회원 정보입니다.";
+    }
+
+    return null;
+}
 
 export async function POST(req: NextRequest) {
     const clientIp = getClientIp(req.headers);
@@ -96,6 +115,10 @@ export async function POST(req: NextRequest) {
         return response;
     } catch (error) {
         console.error("❌ 회원가입 오류", error);
+        const duplicateMessage = getDuplicateSignupMessage(error);
+        if (duplicateMessage) {
+            return NextResponse.json({ error: duplicateMessage }, { status: 409 });
+        }
         if (error instanceof SignUpTokenPersistenceError) {
             return NextResponse.json(
                 { error: "Account created, but sign-in token setup failed. Please sign in again." },


### PR DESCRIPTION
- 네트워크 오류 시 입력값 유지 + 재시도 가능
- 가입 요청 중 버튼 disabled 처리로 연속 클릭 방지
- 가입 성공 후 fetchUser() 실패는 “가입 실패”와 분리해서 로그인 페이지로 안내
-  Prisma unique constraint를 409로 응답