### PR TITLE
회원 탈퇴 및 개인정보 삭제 기능 구현

### DIFF
--- a/app/account/delete/page.tsx
+++ b/app/account/delete/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/common";
+import { useUserStore } from "@/utils/stores/userStore";
+
+export default function DeleteAccountPage() {
+  const router = useRouter();
+  const clearUser = useUserStore((state) => state.clearUser);
+  const [password, setPassword] = useState("");
+  const [confirmText, setConfirmText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch("/api/auth/delete-account", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ password, confirmText }),
+      });
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(data.error ?? "회원 탈퇴에 실패했습니다.");
+      }
+
+      clearUser();
+      router.replace("/");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "회원 탈퇴에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="flex min-h-screen flex-col overflow-hidden px-5 py-6 text-[#4A3F2F]"
+      style={{
+        backgroundImage: "url('/images/backgrounds/bg_01.png')",
+        backgroundSize: "100% 100%",
+        backgroundRepeat: "no-repeat",
+      }}
+    >
+      <div className="mx-auto flex w-full max-w-[520px] items-center pb-4">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="text-2xl text-white"
+          aria-label="뒤로가기"
+        >
+          ←
+        </button>
+        <h1 className="flex-1 pr-6 text-center font-galmuri11-bold text-xl text-white">회원 탈퇴</h1>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="mx-auto w-full max-w-[520px] border-[3px] border-[#4A3F2F] bg-[#fffdf2] p-5 text-[13px] leading-6 shadow-[4px_4px_0_#c9b178]"
+      >
+        <h2 className="mb-3 text-[17px] font-bold text-[#C84B3A]">탈퇴 전 꼭 확인해주세요</h2>
+        <ul className="mb-5 list-disc space-y-2 pl-5">
+          <li>캐릭터, 스탯, 퀘스트, 완료 기록, 칭호, 엔딩 기록이 모두 삭제됩니다.</li>
+          <li>삭제는 트랜잭션으로 처리되며 실패 시 일부 데이터만 삭제된 상태로 남지 않습니다.</li>
+          <li>탈퇴가 완료되면 Access Token과 Refresh Token 쿠키가 제거됩니다.</li>
+          <li>탈퇴 후에는 기존 토큰으로 서비스 API를 사용할 수 없습니다.</li>
+        </ul>
+
+        <label className="mb-4 block">
+          <span className="mb-1 block font-bold">이메일 계정 비밀번호 확인</span>
+          <input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="w-full border-2 border-[#4A3F2F] bg-white px-3 py-2 outline-none"
+            autoComplete="current-password"
+            placeholder="이메일 가입 계정만 입력"
+          />
+        </label>
+
+        <label className="mb-4 block">
+          <span className="mb-1 block font-bold">소셜 계정 확인 문구</span>
+          <input
+            type="text"
+            value={confirmText}
+            onChange={(event) => setConfirmText(event.target.value)}
+            className="w-full border-2 border-[#4A3F2F] bg-white px-3 py-2 outline-none"
+            placeholder="회원탈퇴"
+          />
+        </label>
+
+        {error && <p className="mb-4 border-2 border-[#C84B3A] bg-[#FDE9E6] p-3 text-[#C84B3A]">{error}</p>}
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button type="button" size="M" state="outline" onClick={() => router.back()} disabled={isSubmitting}>
+            취소
+          </Button>
+          <Button type="submit" size="M" state="error" disabled={isSubmitting}>
+            {isSubmitting ? "처리 중" : "탈퇴하기"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/api/auth/delete-account/route.ts
+++ b/app/api/auth/delete-account/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { VerifyPasswordUsecase } from "@/application/usecases/auth/VerifyPasswordUsecase";
+import { RdAuthenticationRepository } from "@/infrastructure/repositories/RdAuthenticationRepository";
+import { prisma } from "@/lib/prisma";
+import { deleteUserAccountData } from "@/utils/accountDeletion";
+import { getUserFromCookie } from "@/utils/auth";
+
+const SOCIAL_DELETE_CONFIRM_TEXT = "회원탈퇴";
+
+type DeleteAccountBody = {
+  password?: unknown;
+  confirmText?: unknown;
+};
+
+function clearAuthCookies(response: NextResponse) {
+  response.cookies.set("accessToken", "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    expires: new Date(0),
+  });
+
+  response.cookies.set("refreshToken", "", {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    expires: new Date(0),
+  });
+}
+
+export async function DELETE(req: NextRequest) {
+  const { user } = await getUserFromCookie(req);
+  if (!user) {
+    return NextResponse.json({ error: "인증되지 않은 사용자입니다." }, { status: 401 });
+  }
+
+  const account = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { id: true, loginId: true, password: true, provider: true },
+  });
+
+  if (!account) {
+    return NextResponse.json({ error: "이미 탈퇴했거나 존재하지 않는 사용자입니다." }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as DeleteAccountBody;
+
+  if (account.provider === "email") {
+    if (typeof body.password !== "string" || body.password.trim().length === 0) {
+      return NextResponse.json({ error: "비밀번호를 입력해주세요." }, { status: 400 });
+    }
+
+    if (!account.password) {
+      return NextResponse.json({ error: "비밀번호 확인이 불가능한 계정입니다." }, { status: 400 });
+    }
+
+    const isPasswordValid = await new VerifyPasswordUsecase().execute(body.password, account.password);
+    if (!isPasswordValid) {
+      return NextResponse.json({ error: "비밀번호가 올바르지 않습니다." }, { status: 401 });
+    }
+  } else if (body.confirmText !== SOCIAL_DELETE_CONFIRM_TEXT) {
+    return NextResponse.json(
+      { error: `소셜 계정 탈퇴를 확인하려면 '${SOCIAL_DELETE_CONFIRM_TEXT}'를 입력해주세요.` },
+      { status: 400 }
+    );
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await deleteUserAccountData(tx, account.id);
+  });
+
+  try {
+    await new RdAuthenticationRepository().deleteRefreshToken(account.loginId);
+  } catch (error) {
+    console.error("회원 탈퇴 후 refresh token 삭제 실패:", error);
+  }
+
+  const response = NextResponse.json({ message: "회원 탈퇴가 완료되었습니다." }, { status: 200 });
+  clearAuthCookies(response);
+  return response;
+}

--- a/utils/accountDeletion.test.ts
+++ b/utils/accountDeletion.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { deleteUserAccountData } from "@/utils/accountDeletion";
+
+function createClientMock(characterIds: number[], questIds: number[]) {
+  return {
+    character: {
+      findMany: vi.fn().mockResolvedValue(characterIds.map((id) => ({ id }))),
+      deleteMany: vi.fn().mockResolvedValue({ count: characterIds.length }),
+    },
+    quest: {
+      findMany: vi.fn().mockResolvedValue(questIds.map((id) => ({ id }))),
+      deleteMany: vi.fn().mockResolvedValue({ count: questIds.length }),
+    },
+    successDay: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    subTask: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    status: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    userTitle: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    endingHistory: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    user: { delete: vi.fn().mockResolvedValue({ id: 1 }) },
+  };
+}
+
+describe("deleteUserAccountData", () => {
+  it("deletes dependent account data before deleting the user", async () => {
+    const client = createClientMock([10], [100, 101]);
+
+    await deleteUserAccountData(client as never, 1);
+
+    expect(client.successDay.deleteMany).toHaveBeenCalledWith({ where: { questId: { in: [100, 101] } } });
+    expect(client.subTask.deleteMany).toHaveBeenCalledWith({ where: { questId: { in: [100, 101] } } });
+    expect(client.quest.deleteMany).toHaveBeenCalledWith({ where: { characterId: { in: [10] } } });
+    expect(client.status.deleteMany).toHaveBeenCalledWith({ where: { characterId: { in: [10] } } });
+    expect(client.userTitle.deleteMany).toHaveBeenCalledWith({ where: { characterId: { in: [10] } } });
+    expect(client.endingHistory.deleteMany).toHaveBeenCalledWith({ where: { characterId: { in: [10] } } });
+    expect(client.character.deleteMany).toHaveBeenCalledWith({ where: { id: { in: [10] } } });
+    expect(client.user.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it("deletes the user even when no character exists", async () => {
+    const client = createClientMock([], []);
+
+    await deleteUserAccountData(client as never, 1);
+
+    expect(client.quest.findMany).not.toHaveBeenCalled();
+    expect(client.successDay.deleteMany).not.toHaveBeenCalled();
+    expect(client.user.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+});

--- a/utils/accountDeletion.ts
+++ b/utils/accountDeletion.ts
@@ -1,0 +1,32 @@
+import type { Prisma } from "@prisma/client";
+
+type AccountDeletionClient = Prisma.TransactionClient;
+
+export async function deleteUserAccountData(client: AccountDeletionClient, userId: number) {
+  const characters = await client.character.findMany({
+    where: { userId },
+    select: { id: true },
+  });
+  const characterIds = characters.map((character) => character.id);
+
+  if (characterIds.length > 0) {
+    const quests = await client.quest.findMany({
+      where: { characterId: { in: characterIds } },
+      select: { id: true },
+    });
+    const questIds = quests.map((quest) => quest.id);
+
+    if (questIds.length > 0) {
+      await client.successDay.deleteMany({ where: { questId: { in: questIds } } });
+      await client.subTask.deleteMany({ where: { questId: { in: questIds } } });
+    }
+
+    await client.quest.deleteMany({ where: { characterId: { in: characterIds } } });
+    await client.status.deleteMany({ where: { characterId: { in: characterIds } } });
+    await client.userTitle.deleteMany({ where: { characterId: { in: characterIds } } });
+    await client.endingHistory.deleteMany({ where: { characterId: { in: characterIds } } });
+    await client.character.deleteMany({ where: { id: { in: characterIds } } });
+  }
+
+  await client.user.delete({ where: { id: userId } });
+}

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -4,12 +4,22 @@ import { VerifyAccessTokenUsecase } from "@/application/usecases/auth/VerifyAcce
 import { VerifyRefreshTokenUsecase } from "@/application/usecases/auth/VerifyRefreshTokenUsecase";
 import { GenerateAccessTokenUsecase } from "@/application/usecases/auth/GenerateAccessTokenUsecase";
 import { RdAuthenticationRepository } from "@/infrastructure/repositories/RdAuthenticationRepository";
+import { prisma } from "@/lib/prisma";
 
 interface UserPayload extends JWTPayload {
   id: number;
   loginId: string;
   nickname?: string;
   createdAt?: string;
+}
+
+async function isActiveUser(id: number, loginId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id },
+    select: { loginId: true },
+  });
+
+  return user?.loginId === loginId;
 }
 
 export async function getUserFromCookie(
@@ -28,7 +38,16 @@ export async function getUserFromCookie(
 
     const payload = await verifyAccessTokenUsecase.execute(accessToken);
     if (payload) {
-      return { user: payload as UserPayload };
+      const id = Number(payload.id);
+      const loginId = payload.loginId;
+      if (!Number.isFinite(id) || typeof loginId !== "string") {
+        return { user: null };
+      }
+      if (!(await isActiveUser(id, loginId))) {
+        return { user: null };
+      }
+
+      return { user: { ...payload, id, loginId } as UserPayload };
     }
 
     if (!refreshToken) {
@@ -43,6 +62,9 @@ export async function getUserFromCookie(
     const id = Number(refreshPayload.id);
     const loginId = refreshPayload.loginId;
     if (!Number.isFinite(id) || typeof loginId !== "string") {
+      return { user: null };
+    }
+    if (!(await isActiveUser(id, loginId))) {
       return { user: null };
     }
 


### PR DESCRIPTION
- 회원 탈퇴 전용 API와 경고 화면 추가
- 이메일 계정 비밀번호 재확인 및 소셜 계정 확인 문구 검증
- 캐릭터, 스탯, 퀘스트, 완료 기록, 칭호, 엔딩 기록 삭제를 트랜잭션으로 처리
- Refresh Token 폐기 및 인증 쿠키 삭제
- 삭제된 계정의 기존 Access Token 접근 차단
- 계정 데이터 삭제 순서 단위 테스트 추가